### PR TITLE
Fix bug in Queue where we would store a pointer to the value provided by the range func

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -61,7 +61,8 @@ type generalAction struct {
 func (q *Queue) Tasks() []*Task {
 	tasks := make([]*Task, len(q.Raw.Items))
 	for i, t := range q.Raw.Items {
-		tasks[i] = &Task{Jenkins: q.Jenkins, Queue: q, Raw: &t}
+		copyItem := t
+		tasks[i] = &Task{Jenkins: q.Jenkins, Queue: q, Raw: &copyItem}
 	}
 	return tasks
 }
@@ -69,7 +70,8 @@ func (q *Queue) Tasks() []*Task {
 func (q *Queue) GetTaskById(id int64) *Task {
 	for _, t := range q.Raw.Items {
 		if t.ID == id {
-			return &Task{Jenkins: q.Jenkins, Queue: q, Raw: &t}
+			copyItem := t
+			return &Task{Jenkins: q.Jenkins, Queue: q, Raw: &copyItem}
 		}
 	}
 	return nil
@@ -79,7 +81,8 @@ func (q *Queue) GetTasksForJob(name string) []*Task {
 	tasks := make([]*Task, 0)
 	for _, t := range q.Raw.Items {
 		if t.Task.Name == name {
-			tasks = append(tasks, &Task{Jenkins: q.Jenkins, Queue: q, Raw: &t})
+			copyItem := t
+			tasks = append(tasks, &Task{Jenkins: q.Jenkins, Queue: q, Raw: &copyItem})
 		}
 	}
 	return tasks


### PR DESCRIPTION
This is a typical go gotcha where the value given by `range` is swapped in-place rather than reallocated.  Therefore pointer will always land on the value last looped over by range.